### PR TITLE
Improve API and Docs examples

### DIFF
--- a/Examples/ApiExamples/ApiExamples/ExDocument.cs
+++ b/Examples/ApiExamples/ApiExamples/ExDocument.cs
@@ -48,7 +48,7 @@ namespace ApiExamples
         public void Constructor()
         {
             //ExStart
-            //ExFor:Document.#ctor(Boolean)
+            //ExFor:Document.#ctor()
             //ExFor:Document.#ctor(String,LoadOptions)
             //ExSummary:Shows how to create and load documents.
             // There are two ways of creating a Document object using Aspose.Words.
@@ -1488,7 +1488,7 @@ namespace ApiExamples
         public void ImageSaveOptions()
         {
             //ExStart
-            //ExFor:Document.Save(Stream, String, Saving.SaveOptions)
+            //ExFor:Document.Save(String, Saving.SaveOptions)
             //ExFor:SaveOptions.UseAntiAliasing
             //ExFor:SaveOptions.UseHighQualityRendering
             //ExSummary:Shows how to improve the quality of a rendered document with SaveOptions.

--- a/Examples/ApiExamples/ApiExamples/ExDocumentProperties.cs
+++ b/Examples/ApiExamples/ApiExamples/ExDocumentProperties.cs
@@ -45,9 +45,9 @@ namespace ApiExamples
                 Console.WriteLine($"\tType:\t{docProperty.Type}");
 
                 // Some properties may store multiple values.
-                if (docProperty.Value is Array)
+                if (docProperty.Value is ICollection<object>)
                 {
-                    foreach (object value in docProperty.Value as Array)
+                    foreach (object value in docProperty.Value as ICollection<object>)
                         Console.WriteLine($"\tValue:\t\"{value}\"");
                 }
                 else

--- a/Examples/ApiExamples/ApiExamples/ExDocumentVisitor.cs
+++ b/Examples/ApiExamples/ApiExamples/ExDocumentVisitor.cs
@@ -1078,7 +1078,7 @@ namespace ApiExamples
             doc.Accept(visitor);
 
             Console.WriteLine(visitor.GetText());
-            TestSmartTagToText(visitor); //ExEnd
+            TestSmartTagToText(visitor); //ExSkip
         }
 
         /// <summary>

--- a/Examples/ApiExamples/ApiExamples/ExDrawing.cs
+++ b/Examples/ApiExamples/ApiExamples/ExDrawing.cs
@@ -334,7 +334,6 @@ namespace ApiExamples
         //ExFor:DocumentVisitor.VisitGroupShapeStart(GroupShape)
         //ExFor:Drawing.GroupShape
         //ExFor:Drawing.GroupShape.#ctor(DocumentBase)
-        //ExFor:Drawing.GroupShape.#ctor(DocumentBase,Drawing.ShapeMarkupLanguage)
         //ExFor:Drawing.GroupShape.Accept(DocumentVisitor)
         //ExFor:ShapeBase.IsGroup
         //ExFor:ShapeBase.ShapeType

--- a/Examples/ApiExamples/ApiExamples/ExField.cs
+++ b/Examples/ApiExamples/ApiExamples/ExField.cs
@@ -1120,7 +1120,6 @@ namespace ApiExamples
             //ExFor:FieldCollection.Clear
             //ExFor:FieldCollection.Item(Int32)
             //ExFor:FieldCollection.Remove(Field)
-            //ExFor:FieldCollection.Remove(FieldStart)
             //ExFor:FieldCollection.RemoveAt(Int32)
             //ExFor:Field.Remove
             //ExSummary:Shows how to remove fields from a field collection.

--- a/Examples/ApiExamples/ApiExamples/ExFont.cs
+++ b/Examples/ApiExamples/ApiExamples/ExFont.cs
@@ -859,10 +859,10 @@ namespace ApiExamples
             // using the above methods to reference old and new styles.
             foreach (Run run in doc.GetChildNodes(NodeType.Run, true).OfType<Run>())
             {
-                if (run.Font.StyleName.Equals("Emphasis"))
+                if (run.Font.StyleName == "Emphasis")
                     run.Font.StyleName = "Strong";
 
-                if (run.Font.StyleIdentifier.Equals(StyleIdentifier.IntenseEmphasis))
+                if (run.Font.StyleIdentifier == StyleIdentifier.IntenseEmphasis)
                     run.Font.StyleIdentifier = StyleIdentifier.Strong;
             }
 

--- a/Examples/ApiExamples/ApiExamples/ExFont.cs
+++ b/Examples/ApiExamples/ApiExamples/ExFont.cs
@@ -8,6 +8,7 @@
 #if NET462 || NETCOREAPP2_1 || JAVA
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;
 using System.IO;
@@ -1346,10 +1347,10 @@ namespace ApiExamples
             //ExSummary:Shows how to access and print details of each font in a document.
             Document doc = new Document(MyDir + "Document.docx");
             
-            IEnumerator fontCollectionEnumerator = doc.FontInfos.GetEnumerator();
+            IEnumerator<FontInfo> fontCollectionEnumerator = doc.FontInfos.GetEnumerator();
             while (fontCollectionEnumerator.MoveNext())
             {
-                FontInfo fontInfo = (FontInfo)fontCollectionEnumerator.Current;
+                FontInfo fontInfo = fontCollectionEnumerator.Current;
                 if (fontInfo != null)
                 {
                     Console.WriteLine("Font name: " + fontInfo.Name);

--- a/Examples/ApiExamples/ApiExamples/ExFontSettings.cs
+++ b/Examples/ApiExamples/ApiExamples/ExFontSettings.cs
@@ -327,11 +327,11 @@ namespace ApiExamples
             HandleDocumentSubstitutionWarnings substitutionWarningHandler = new HandleDocumentSubstitutionWarnings();
             doc.WarningCallback = substitutionWarningHandler;
 
-            ArrayList fontSources = new ArrayList(FontSettings.DefaultInstance.GetFontsSources());
+            List<FontSourceBase> fontSources = new List<FontSourceBase>(FontSettings.DefaultInstance.GetFontsSources());
             FolderFontSource folderFontSource = new FolderFontSource(FontsDir, true);
             fontSources.Add(folderFontSource);
 
-            FontSourceBase[] updatedFontSources = (FontSourceBase[])fontSources.ToArray(typeof(FontSourceBase));
+            FontSourceBase[] updatedFontSources = fontSources.ToArray();
             FontSettings.DefaultInstance.SetFontsSources(updatedFontSources);
 
             doc.Save(ArtifactsDir + "Font.GetSubstitutionWithoutSuffixes.pdf");

--- a/Examples/ApiExamples/ApiExamples/ExFontSettings.cs
+++ b/Examples/ApiExamples/ApiExamples/ExFontSettings.cs
@@ -131,11 +131,11 @@ namespace ApiExamples
                 if (info.WarningType == WarningType.FontSubstitution)
                 {
                     Console.WriteLine("Font substitution: " + info.Description);
-                    FontWarnings.Warning(info); //ExSkip
+                    FontWarnings.Warning(info);
                 }
             }
 
-            public WarningInfoCollection FontWarnings = new WarningInfoCollection(); //ExSkip
+            public WarningInfoCollection FontWarnings = new WarningInfoCollection();
         }
 
         //ExStart

--- a/Examples/ApiExamples/ApiExamples/ExMailMergeCustom.cs
+++ b/Examples/ApiExamples/ApiExamples/ExMailMergeCustom.cs
@@ -34,7 +34,7 @@ namespace ApiExamples
             builder.InsertParagraph();
             builder.InsertField(" MERGEFIELD Address ");
 
-            CustomerList customers = new CustomerList();
+            List<Customer> customers = new List<Customer>();
             customers.Add(new Customer("Thomas Hardy", "120 Hanover Sq., London"));
             customers.Add(new Customer("Paolo Accorti", "Via Monte Bianco 34, Torino"));
 
@@ -63,24 +63,12 @@ namespace ApiExamples
         }
 
         /// <summary>
-        /// An example of a typed collection that contains your "data" objects.
-        /// </summary>
-        public class CustomerList : ArrayList
-        {
-            public new Customer this[int index]
-            {
-                get { return (Customer) base[index]; }
-                set { base[index] = value; }
-            }
-        }
-
-        /// <summary>
         /// A custom mail merge data source that you implement to allow Aspose.Words 
         /// to mail merge data from your Customer objects into Microsoft Word documents.
         /// </summary>
         public class CustomerMailMergeDataSource : IMailMergeDataSource
         {
-            public CustomerMailMergeDataSource(CustomerList customers)
+            public CustomerMailMergeDataSource(List<Customer> customers)
             {
                 mCustomers = customers;
 
@@ -138,12 +126,12 @@ namespace ApiExamples
                 get { return (mRecordIndex >= mCustomers.Count); }
             }
 
-            private readonly CustomerList mCustomers;
+            private readonly List<Customer> mCustomers;
             private int mRecordIndex;
         }
         //ExEnd
 
-        private void TestCustomDataSource(CustomerList customerList, Document doc)
+        private void TestCustomDataSource(List<Customer> customerList, Document doc)
         {
             string[][] mergeData = new string[customerList.Count][];
 

--- a/Examples/ApiExamples/ApiExamples/ExMailMergeCustomNested.cs
+++ b/Examples/ApiExamples/ApiExamples/ExMailMergeCustomNested.cs
@@ -78,12 +78,12 @@ namespace ApiExamples
             {
                 FullName = aFullName;
                 Address = anAddress;
-                Orders = new OrderList();
+                Orders = new List<Order>();
             }
 
             public string FullName { get; set; }
             public string Address { get; set; }
-            public OrderList Orders { get; set; }
+            public List<Order> Orders { get; set; }
         }
 
         /// <summary>
@@ -111,18 +111,6 @@ namespace ApiExamples
 
             public string Name { get; set; }
             public int Quantity { get; set; }
-        }
-
-        /// <summary>
-        /// An example of a typed collection that contains your "data" objects.
-        /// </summary>
-        public class OrderList : ArrayList
-        {
-            public new Order this[int index]
-            {
-                get { return (Order) base[index]; }
-                set { base[index] = value; }
-            }
         }
 
         /// <summary>
@@ -205,7 +193,7 @@ namespace ApiExamples
 
         public class OrderMailMergeDataSource : IMailMergeDataSource
         {
-            public OrderMailMergeDataSource(OrderList orders)
+            public OrderMailMergeDataSource(List<Order> orders)
             {
                 mOrders = orders;
 
@@ -266,7 +254,7 @@ namespace ApiExamples
                 get { return (mRecordIndex >= mOrders.Count); }
             }
 
-            private readonly OrderList mOrders;
+            private readonly List<Order> mOrders;
             private int mRecordIndex;
         }
         //ExEnd

--- a/Examples/ApiExamples/ApiExamples/ExMailMergeEvent.cs
+++ b/Examples/ApiExamples/ApiExamples/ExMailMergeEvent.cs
@@ -183,7 +183,7 @@ namespace ApiExamples
             /// </summary>
             void IFieldMergingCallback.FieldMerging(FieldMergingArgs args)
             {
-                if (args.DocumentFieldName.Equals("CourseName"))
+                if (args.DocumentFieldName == "CourseName")
                 {
                     Assert.AreEqual("StudentCourse", args.TableName);
 
@@ -258,7 +258,7 @@ namespace ApiExamples
                     mBuilder = new DocumentBuilder(args.Document);
 
                 // This is true of we are on the first column, which means we have moved to a new row.
-                if (args.FieldName.Equals("CompanyName"))
+                if (args.FieldName == "CompanyName")
                 {
                     Color rowColor = IsOdd(mRowIdx) ? Color.FromArgb(213, 227, 235) : Color.FromArgb(242, 242, 242);
 

--- a/Examples/ApiExamples/ApiExamples/ExNode.cs
+++ b/Examples/ApiExamples/ApiExamples/ExNode.cs
@@ -254,7 +254,7 @@ namespace ApiExamples
 
                 // A section body can contain Paragraph and Table nodes.
                 // If the node is a Table, remove it from the parent.
-                if (curNode.NodeType.Equals(NodeType.Table))
+                if (curNode.NodeType == NodeType.Table)
                     curNode.Remove();
 
                 curNode = nextNode;

--- a/Examples/ApiExamples/ApiExamples/ExNode.cs
+++ b/Examples/ApiExamples/ApiExamples/ExNode.cs
@@ -380,7 +380,7 @@ namespace ApiExamples
         [Test]
         public void TestNodeIsInsideField()
         {
-            //ExStart:
+            //ExStart
             //ExFor:CompositeNode.SelectNodes
             //ExSummary:Shows how to use an XPath expression to test whether a node is inside a field.
             Document doc = new Document(MyDir + "Mail merge destination - Northwind employees.docx");

--- a/Examples/ApiExamples/ApiExamples/ExNodeImporter.cs
+++ b/Examples/ApiExamples/ApiExamples/ExNodeImporter.cs
@@ -110,7 +110,7 @@ namespace ApiExamples
         /// </summary>
         static void InsertDocument(Node insertionDestination, Document docToInsert)
         {
-            if (insertionDestination.NodeType.Equals(NodeType.Paragraph) || insertionDestination.NodeType.Equals(NodeType.Table))
+            if (insertionDestination.NodeType == NodeType.Paragraph || insertionDestination.NodeType == NodeType.Table)
             {
                 CompositeNode destinationParent = insertionDestination.ParentNode;
 
@@ -122,7 +122,7 @@ namespace ApiExamples
                 foreach (Section srcSection in docToInsert.Sections.OfType<Section>())
                     foreach (Node srcNode in srcSection.Body)
                     {
-                        if (srcNode.NodeType.Equals(NodeType.Paragraph))
+                        if (srcNode.NodeType == NodeType.Paragraph)
                         {
                             Paragraph para = (Paragraph)srcNode;
                             if (para.IsEndOfSection && !para.HasChildNodes)

--- a/Examples/ApiExamples/ApiExamples/ExParagraph.cs
+++ b/Examples/ApiExamples/ApiExamples/ExParagraph.cs
@@ -288,7 +288,7 @@ namespace ApiExamples
         {
             //ExStart
             //ExFor:CompositeNode.Count
-            //ExFor:CompositeNode.GetChildNodes(NodeType[], Boolean)
+            //ExFor:CompositeNode.GetChildNodes(NodeType, Boolean)
             //ExFor:CompositeNode.InsertAfter(Node, Node)
             //ExFor:CompositeNode.InsertBefore(Node, Node)
             //ExFor:CompositeNode.PrependChild(Node) 

--- a/Examples/ApiExamples/ApiExamples/ExPrinting.cs
+++ b/Examples/ApiExamples/ApiExamples/ExPrinting.cs
@@ -287,7 +287,7 @@ namespace ApiExamples
             printDlg.PrinterSettings.FromPage = 1;
             printDlg.PrinterSettings.ToPage = doc.PageCount;
 
-            if (!printDlg.ShowDialog().Equals(DialogResult.OK))
+            if (printDlg.ShowDialog() != DialogResult.OK)
                 return;
 
             // Create the "Aspose.Words" implementation of the .NET print document,

--- a/Examples/ApiExamples/ApiExamples/ExRange.cs
+++ b/Examples/ApiExamples/ApiExamples/ExRange.cs
@@ -610,7 +610,7 @@ namespace ApiExamples
         /// </summary>
         private static void InsertDocument(Node insertionDestination, Document docToInsert)
         {
-            if (insertionDestination.NodeType.Equals(NodeType.Paragraph) || insertionDestination.NodeType.Equals(NodeType.Table))
+            if (insertionDestination.NodeType == NodeType.Paragraph || insertionDestination.NodeType == NodeType.Table)
             {
                 CompositeNode dstStory = insertionDestination.ParentNode;
 
@@ -621,7 +621,7 @@ namespace ApiExamples
                     foreach (Node srcNode in srcSection.Body)
                     {
                         // Skip the node if it is the last empty paragraph in a section.
-                        if (srcNode.NodeType.Equals(NodeType.Paragraph))
+                        if (srcNode.NodeType == NodeType.Paragraph)
                         {
                             Paragraph para = (Paragraph)srcNode;
                             if (para.IsEndOfSection && !para.HasChildNodes)

--- a/Examples/ApiExamples/ApiExamples/ExRange.cs
+++ b/Examples/ApiExamples/ApiExamples/ExRange.cs
@@ -480,11 +480,11 @@ namespace ApiExamples
             //ExEnd
         }
 
-        [TestCase(true)]
-        [TestCase(false)]
         //ExStart
         //ExFor:FindReplaceOptions.UseLegacyOrder
         //ExSummary:Shows how to change the searching order of nodes when performing a find-and-replace text operation.
+        [TestCase(true)] // ExSkip
+        [TestCase(false)] // ExSkip
         public void UseLegacyOrder(bool useLegacyOrder)
         {
             Document doc = new Document();

--- a/Examples/ApiExamples/ApiExamples/ExRenameMergeFields.cs
+++ b/Examples/ApiExamples/ApiExamples/ExRenameMergeFields.cs
@@ -41,7 +41,7 @@ namespace ApiExamples
             NodeCollection fieldStarts = doc.GetChildNodes(NodeType.FieldStart, true);
             foreach (FieldStart fieldStart in fieldStarts.OfType<FieldStart>())
             {
-                if (fieldStart.FieldType.Equals(FieldType.FieldMergeField))
+                if (fieldStart.FieldType == FieldType.FieldMergeField)
                 {
                     MergeField mergeField = new MergeField(fieldStart);
                     mergeField.Name = mergeField.Name + "_Renamed";
@@ -59,7 +59,7 @@ namespace ApiExamples
     {
         internal MergeField(FieldStart fieldStart)
         {
-            if (!fieldStart.FieldType.Equals(FieldType.FieldMergeField))
+            if (fieldStart.FieldType != FieldType.FieldMergeField)
                 throw new ArgumentException("Field start type must be FieldMergeField.");
 
             mFieldStart = fieldStart;
@@ -116,7 +116,7 @@ namespace ApiExamples
         {
             for (Node node = startNode; node != null; node = node.NextSibling)
             {
-                if (node.NodeType.Equals(nodeType))
+                if (node.NodeType == nodeType)
                     return node;
             }
 

--- a/Examples/ApiExamples/ApiExamples/ExReplaceHyperlinks.cs
+++ b/Examples/ApiExamples/ApiExamples/ExReplaceHyperlinks.cs
@@ -33,7 +33,7 @@ namespace ApiExamples
 
             foreach (FieldStart fieldStart in fieldStarts.OfType<FieldStart>())
             {
-                if (fieldStart.FieldType.Equals(FieldType.FieldHyperlink))
+                if (fieldStart.FieldType == FieldType.FieldHyperlink)
                 {
                     Hyperlink hyperlink = new Hyperlink(fieldStart);
 
@@ -75,7 +75,7 @@ namespace ApiExamples
         {
             if (fieldStart == null)
                 throw new ArgumentNullException("fieldStart");
-            if (!fieldStart.FieldType.Equals(FieldType.FieldHyperlink))
+            if (fieldStart.FieldType != FieldType.FieldHyperlink)
                 throw new ArgumentException("Field start type must be FieldHyperlink.");
 
             mFieldStart = fieldStart;
@@ -161,7 +161,7 @@ namespace ApiExamples
         {
             for (Node node = startNode; node != null; node = node.NextSibling)
             {
-                if (node.NodeType.Equals(nodeType))
+                if (node.NodeType == nodeType)
                     return node;
             }
 

--- a/Examples/ApiExamples/ApiExamples/ExShape.cs
+++ b/Examples/ApiExamples/ApiExamples/ExShape.cs
@@ -1687,7 +1687,6 @@ namespace ApiExamples
         //ExStart
         //ExFor:Shape.Accept(DocumentVisitor)
         //ExFor:Shape.Chart
-        //ExFor:Shape.Clone(Boolean, INodeCloningListener)
         //ExFor:Shape.ExtrusionEnabled
         //ExFor:Shape.Filled
         //ExFor:Shape.HasChart

--- a/Examples/ApiExamples/ApiExamples/ExShape.cs
+++ b/Examples/ApiExamples/ApiExamples/ExShape.cs
@@ -864,7 +864,7 @@ namespace ApiExamples
 
             foreach (Shape shape in shapes)
             {
-                if (shape.ShapeType.Equals(ShapeType.TextBox))
+                if (shape.ShapeType == ShapeType.TextBox)
                 {
                     Shape replacementShape = new Shape(doc, ShapeType.Image);
                     replacementShape.ImageData.SetImage(ImageDir + "Logo.jpg");

--- a/Examples/ApiExamples/ApiExamples/ExSignDocumentCustom.cs
+++ b/Examples/ApiExamples/ApiExamples/ExSignDocumentCustom.cs
@@ -44,8 +44,7 @@ namespace ApiExamples
 
             CreateSignees();
 
-            Signee signeeInfo =
-                (from c in mSignees where c.Name == signeeName select c).FirstOrDefault();
+            Signee signeeInfo = mSignees.Find(c => c.Name == signeeName);
 
             if (signeeInfo != null)
                 SignDocument(srcDocumentPath, dstDocumentPath, signeeInfo, certificatePath, certificatePassword);

--- a/Examples/ApiExamples/ApiExamples/ExStyles.cs
+++ b/Examples/ApiExamples/ApiExamples/ExStyles.cs
@@ -96,7 +96,7 @@ namespace ApiExamples
         public void StyleCollection()
         {
             //ExStart
-            //ExFor:StyleCollection.Add(Style)
+            //ExFor:StyleCollection.Add(StyleType,String)
             //ExFor:StyleCollection.Count
             //ExFor:StyleCollection.DefaultFont
             //ExFor:StyleCollection.DefaultParagraphFormat

--- a/Examples/ApiExamples/ApiExamples/ExTabStop.cs
+++ b/Examples/ApiExamples/ApiExamples/ExTabStop.cs
@@ -81,8 +81,8 @@ namespace ApiExamples
             TabStopCollection tabStops = builder.ParagraphFormat.TabStops;
 
             // 72 points is one "inch" on the Microsoft Word tab stop ruler.
-            tabStops.Add(new TabStop(72));
-            tabStops.Add(new TabStop(432, TabAlignment.Right, TabLeader.Dashes));
+            tabStops.Add(new TabStop(72.0));
+            tabStops.Add(new TabStop(432.0, TabAlignment.Right, TabLeader.Dashes));
 
             Assert.AreEqual(2, tabStops.Count);
             Assert.IsFalse(tabStops[0].IsClear);

--- a/Examples/ApiExamples/ApiExamples/ExTable.cs
+++ b/Examples/ApiExamples/ApiExamples/ExTable.cs
@@ -1389,7 +1389,6 @@ namespace ApiExamples
             //ExFor:ConditionalStyleCollection.EvenRowBanding
             //ExFor:ConditionalStyleCollection.FirstColumn
             //ExFor:ConditionalStyleCollection.Item(ConditionalStyleType)
-            //ExFor:ConditionalStyleCollection.Item(TableStyleOverrideType)
             //ExFor:ConditionalStyleCollection.Item(Int32)
             //ExFor:ConditionalStyleCollection.OddColumnBanding
             //ExFor:ConditionalStyleCollection.OddRowBanding

--- a/Examples/ApiExamples/ApiExamples/ExTableColumn.cs
+++ b/Examples/ApiExamples/ApiExamples/ExTableColumn.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Aspose.Words;
@@ -42,7 +43,7 @@ namespace ApiExamples
             /// </summary>
             public Cell[] Cells
             {
-                get { return (Cell[]) GetColumnCells().ToArray(typeof(Cell)); }
+                get { return GetColumnCells().ToArray(); }
             }
 
             /// <summary>
@@ -104,9 +105,9 @@ namespace ApiExamples
             /// <summary>
             /// Provides an up-to-date collection of cells which make up the column represented by this facade.
             /// </summary>
-            private ArrayList GetColumnCells()
+            private List<Cell> GetColumnCells()
             {
-                ArrayList columnCells = new ArrayList();
+                List<Cell> columnCells = new List<Cell>();
 
                 foreach (Row row in mTable.Rows.OfType<Row>())
                 {

--- a/Examples/DocsExamples/DocsExamples/File Formats and Conversions/Load Options/Working with LoadOptions.cs
+++ b/Examples/DocsExamples/DocsExamples/File Formats and Conversions/Load Options/Working with LoadOptions.cs
@@ -183,11 +183,11 @@ namespace DocsExamples.File_Formats_and_Conversions.Load_Options
         [Test]
         public void LoadChm()
         {
-            // ExStart:LoadCHM
+            //ExStart:LoadCHM
             LoadOptions loadOptions = new LoadOptions { Encoding = Encoding.GetEncoding("windows-1251") };
 
             Document doc = new Document(MyDir + "HTML help.chm", loadOptions);
-            // ExEnd:LoadCHM
+            //ExEnd:LoadCHM
         }
     }
 }

--- a/Examples/DocsExamples/DocsExamples/File Formats and Conversions/Save Options/Working with MarkdownSaveOptions.cs
+++ b/Examples/DocsExamples/DocsExamples/File Formats and Conversions/Save Options/Working with MarkdownSaveOptions.cs
@@ -43,14 +43,14 @@ namespace DocsExamples.File_Formats_and_Conversions.Save_Options
         [Test]
         public void SetImagesFolder()
         {
-            // ExStart:SetImagesFolder
+            //ExStart:SetImagesFolder
             Document doc = new Document(MyDir + "Image bullet points.docx");
 
             MarkdownSaveOptions saveOptions = new MarkdownSaveOptions { ImagesFolder = ArtifactsDir + "Images" };
 
             using (MemoryStream stream = new MemoryStream())
                 doc.Save(stream, saveOptions);
-            // ExEnd:SetImagesFolder
+            //ExEnd:SetImagesFolder
         }
     }
 }

--- a/Examples/DocsExamples/DocsExamples/File Formats and Conversions/Save Options/Working with OoxmlSaveOptions.cs
+++ b/Examples/DocsExamples/DocsExamples/File Formats and Conversions/Save Options/Working with OoxmlSaveOptions.cs
@@ -60,13 +60,13 @@ namespace DocsExamples.File_Formats_and_Conversions.Save_Options
         [Test]
         public void SetCompressionLevel()
         {
-            // ExStart:SetCompressionLevel
+            //ExStart:SetCompressionLevel
             Document doc = new Document(MyDir + "Document.docx");
 
             OoxmlSaveOptions saveOptions = new OoxmlSaveOptions { CompressionLevel = CompressionLevel.SuperFast };
 
             doc.Save(ArtifactsDir + "WorkingWithOoxmlSaveOptions.SetCompressionLevel.docx", saveOptions);
-            // ExEnd:SetCompressionLevel
+            //ExEnd:SetCompressionLevel
         }
     }
 }

--- a/Examples/DocsExamples/DocsExamples/File Formats and Conversions/Save Options/Working with PdfSaveOptions.cs
+++ b/Examples/DocsExamples/DocsExamples/File Formats and Conversions/Save Options/Working with PdfSaveOptions.cs
@@ -121,14 +121,14 @@ namespace DocsExamples.File_Formats_and_Conversions.Save_Options
         [Test]
         public void DisableEmbedWindowsFonts()
         {
-            // ExStart:DisableEmbedWindowsFonts
+            //ExStart:DisableEmbedWindowsFonts
             Document doc = new Document(MyDir + "Rendering.docx");
 
             // The output PDF will be saved without embedding standard windows fonts.
             PdfSaveOptions saveOptions = new PdfSaveOptions { FontEmbeddingMode = PdfFontEmbeddingMode.EmbedNone };
             
             doc.Save(ArtifactsDir + "WorkingWithPdfSaveOptions.DisableEmbedWindowsFonts.pdf", saveOptions);
-            // ExEnd:DisableEmbedWindowsFonts
+            //ExEnd:DisableEmbedWindowsFonts
         }
 
         [Test]
@@ -260,7 +260,7 @@ namespace DocsExamples.File_Formats_and_Conversions.Save_Options
             saveOptions.OutlineOptions.ExpandedOutlineLevels = 1;
 
             doc.Save(ArtifactsDir + "WorkingWithPdfSaveOptions.SetOutlineOptions.pdf", saveOptions);
-            // ExEnd:SetOutlineOptions
+            //ExEnd:SetOutlineOptions
         }
 
         [Test]

--- a/Examples/DocsExamples/DocsExamples/LINQ Reporting Engine/Helpers/Data Source Objects/BackgroundColor.cs
+++ b/Examples/DocsExamples/DocsExamples/LINQ Reporting Engine/Helpers/Data Source Objects/BackgroundColor.cs
@@ -7,10 +7,10 @@ namespace DocsExamples.LINQ_Reporting_Engine.Helpers.Data_Source_Objects
     {
         public string Name { get; set; }
         public Color Color { get; set; }
-        public int? ColorCode { get; set; } = null;
-        public double? Value1 { get; set; } = null;
-        public double? Value2 { get; set; } = null;
-        public double? Value3 { get; set; } = null;
+        public int? ColorCode { get; set; }
+        public double? Value1 { get; set; }
+        public double? Value2 { get; set; }
+        public double? Value3 { get; set; }
     }
     //ExEnd:Color
 }

--- a/Examples/DocsExamples/DocsExamples/LINQ Reporting Engine/Helpers/Data Source Objects/PointData.cs
+++ b/Examples/DocsExamples/DocsExamples/LINQ Reporting Engine/Helpers/Data Source Objects/PointData.cs
@@ -1,11 +1,11 @@
 ﻿namespace DocsExamples.LINQ_Reporting_Engine.Helpers.Data_Source_Objects
 {
-    // ExStart:PointDataClass
+    //ExStart:PointDataClass
     public class PointData
     {
         public string Time { get; set; }
         public int Flow { get; set; }
         public int Rainfall { get; set; }
     }
-    // ExEnd:PointDataClass
+    //ExEnd:PointDataClass
 }

--- a/Examples/DocsExamples/DocsExamples/Mail Merge and Reporting/Complex examples and helpers/Apply custom logic to empty regions.cs
+++ b/Examples/DocsExamples/DocsExamples/Mail Merge and Reporting/Complex examples and helpers/Apply custom logic to empty regions.cs
@@ -28,7 +28,7 @@ namespace DocsExamples.Mail_Merge_and_Reporting.Custom_examples
             doc.MailMerge.ExecuteWithRegions(data);
 
             // Regions without data and not merged will remain in the document.
-            Document mergedDoc = doc.Clone(); // ExSkip
+            Document mergedDoc = doc.Clone(); //ExSkip
             
             // Apply logic to each unused region left in the document.
             ExecuteCustomLogicOnEmptyRegions(doc, new EmptyRegionsHandler());

--- a/Examples/DocsExamples/DocsExamples/Mail Merge and Reporting/Complex examples and helpers/Apply custom logic to empty regions.cs
+++ b/Examples/DocsExamples/DocsExamples/Mail Merge and Reporting/Complex examples and helpers/Apply custom logic to empty regions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
 using System.Data;
 using Aspose.Words;
 using Aspose.Words.MailMerging;
@@ -45,7 +46,7 @@ namespace DocsExamples.Mail_Merge_and_Reporting.Custom_examples
             doc = mergedDoc.Clone();
             
             //ExStart:ContactDetails 
-            ArrayList regions = new ArrayList();
+            List<string> regions = new List<string>();
             regions.Add("ContactDetails");
 
             // Only handle the ContactDetails region in our handler.
@@ -58,10 +59,10 @@ namespace DocsExamples.Mail_Merge_and_Reporting.Custom_examples
         //ExStart:CreateDataSourceFromDocumentRegions
         /// <summary>
         /// Returns a DataSet object containing a DataTable for the unmerged regions in the specified document.
-        /// If regionsList is null all regions found within the document are included. If an ArrayList instance is present,
+        /// If regionsList is null all regions found within the document are included. If an List instance is present,
         /// the only regions specified in the list found in the document are added.
         /// </summary>
-        private DataSet CreateDataSourceFromDocumentRegions(Document doc, ArrayList regionsList)
+        private DataSet CreateDataSourceFromDocumentRegions(Document doc, List<string> regionsList)
         {
             const string tableStartMarker = "TableStart:";
             DataSet dataSet = new DataSet();
@@ -122,7 +123,7 @@ namespace DocsExamples.Mail_Merge_and_Reporting.Custom_examples
         /// <param name="regionsList">A list of strings corresponding to the region names that are to be handled
         /// by the supplied handler class. Other regions encountered will not be handled and are removed automatically.</param>
         public void ExecuteCustomLogicOnEmptyRegions(Document doc, IFieldMergingCallback handler,
-            ArrayList regionsList)
+            List<string> regionsList)
         {
             // Certain regions can be skipped from applying logic to by not adding
             // the table name inside the CreateEmptyDataSource method. Enable this cleanup option, so any regions

--- a/Examples/DocsExamples/DocsExamples/Mail Merge and Reporting/Complex examples and helpers/Nested MailMerge custom.cs
+++ b/Examples/DocsExamples/DocsExamples/Mail Merge and Reporting/Complex examples and helpers/Nested MailMerge custom.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
 using Aspose.Words;
 using Aspose.Words.MailMerging;
 using NUnit.Framework;
@@ -33,7 +34,7 @@ namespace DocsExamples.Mail_Merge_and_Reporting.Custom_examples
 
             builder.InsertField(" MERGEFIELD TableEnd:Customer");
 
-            CustomerList customers = new CustomerList
+            List<Customer> customers = new List<Customer>
             {
                 new Customer("Thomas Hardy", "120 Hanover Sq., London"),
                 new Customer("Paolo Accorti", "Via Monte Bianco 34, Torino")
@@ -62,24 +63,12 @@ namespace DocsExamples.Mail_Merge_and_Reporting.Custom_examples
             {
                 FullName = aFullName;
                 Address = anAddress;
-                Orders = new OrderList();
+                Orders = new List<Order>();
             }
 
             public string FullName { get; set; }
             public string Address { get; set; }
-            public OrderList Orders { get; set; }
-        }
-
-        /// <summary>
-        /// An example of a typed collection that contains your "data" objects.
-        /// </summary>
-        public class CustomerList : ArrayList
-        {
-            public new Customer this[int index]
-            {
-                get => (Customer) base[index];
-                set => base[index] = value;
-            }
+            public List<Order> Orders { get; set; }
         }
 
         /// <summary>
@@ -98,24 +87,12 @@ namespace DocsExamples.Mail_Merge_and_Reporting.Custom_examples
         }
 
         /// <summary>
-        /// An example of a typed collection that contains your "data" objects.
-        /// </summary>
-        public class OrderList : ArrayList
-        {
-            public new Order this[int index]
-            {
-                get => (Order) base[index];
-                set => base[index] = value;
-            }
-        }
-
-        /// <summary>
         /// A custom mail merge data source that you implement to allow Aspose.Words
         /// to mail merge data from your Customer objects into Microsoft Word documents.
         /// </summary>
         public class CustomerMailMergeDataSource : IMailMergeDataSource
         {
-            public CustomerMailMergeDataSource(CustomerList customers)
+            public CustomerMailMergeDataSource(List<Customer> customers)
             {
                 mCustomers = customers;
 
@@ -177,13 +154,13 @@ namespace DocsExamples.Mail_Merge_and_Reporting.Custom_examples
 
             private bool IsEof => (mRecordIndex >= mCustomers.Count);
 
-            private readonly CustomerList mCustomers;
+            private readonly List<Customer> mCustomers;
             private int mRecordIndex;
         }
 
         public class OrderMailMergeDataSource : IMailMergeDataSource
         {
-            public OrderMailMergeDataSource(OrderList orders)
+            public OrderMailMergeDataSource(List<Order> orders)
             {
                 mOrders = orders;
 
@@ -234,7 +211,7 @@ namespace DocsExamples.Mail_Merge_and_Reporting.Custom_examples
 
             private bool IsEof => mRecordIndex >= mOrders.Count;
 
-            private readonly OrderList mOrders;
+            private readonly List<Order> mOrders;
             private int mRecordIndex;
         }
     }

--- a/Examples/DocsExamples/DocsExamples/Mail Merge and Reporting/Working with Fields.cs
+++ b/Examples/DocsExamples/DocsExamples/Mail Merge and Reporting/Working with Fields.cs
@@ -96,7 +96,7 @@ namespace DocsExamples.Mail_Merge_and_Reporting
         [Test]
         public void MailMergeImageField()
         {
-            // ExStart:MailMergeImageField       
+            //ExStart:MailMergeImageField       
             Document doc = new Document();
             DocumentBuilder builder = new DocumentBuilder(doc);
 
@@ -116,10 +116,10 @@ namespace DocsExamples.Mail_Merge_and_Reporting
             doc.MailMerge.ExecuteWithRegions(new DataSourceRoot());
 
             doc.Save(ArtifactsDir + "WorkingWithFields.MailMergeImageField.docx");
-            // ExEnd:MailMergeImageField
+            //ExEnd:MailMergeImageField
         }
 
-        // ExStart:ImageFieldMergingHandler
+        //ExStart:ImageFieldMergingHandler
         private class ImageFieldMergingHandler : IFieldMergingCallback
         {
             void IFieldMergingCallback.FieldMerging(FieldMergingArgs args)
@@ -139,9 +139,9 @@ namespace DocsExamples.Mail_Merge_and_Reporting
                 args.Shape = shape;
             }
         }
-        // ExEnd:ImageFieldMergingHandler
+        //ExEnd:ImageFieldMergingHandler
 
-        // ExStart:DataSourceRoot
+        //ExStart:DataSourceRoot
         public class DataSourceRoot : IMailMergeDataSourceRoot
         {
             public IMailMergeDataSource GetDataSource(string s)
@@ -179,7 +179,7 @@ namespace DocsExamples.Mail_Merge_and_Reporting
                 }
             }
         }
-        // ExEnd:DataSourceRoot
+        //ExEnd:DataSourceRoot
 
         [Test]
         public void MailMergeAndConditionalField()

--- a/Examples/DocsExamples/DocsExamples/Mail Merge and Reporting/Working with Fields.cs
+++ b/Examples/DocsExamples/DocsExamples/Mail Merge and Reporting/Working with Fields.cs
@@ -326,7 +326,7 @@ namespace DocsExamples.Mail_Merge_and_Reporting
                 if (mBuilder == null)
                     mBuilder = new DocumentBuilder(e.Document);
 
-                if (e.FieldName.Equals("CompanyName"))
+                if (e.FieldName == "CompanyName")
                 {
                     // Select the color depending on whether the row number is even or odd.
                     Color rowColor = IsOdd(mRowIdx) 
@@ -358,7 +358,7 @@ namespace DocsExamples.Mail_Merge_and_Reporting
         /// </summary>
         private static bool IsOdd(int value)
         {
-            return (value / 2 * 2).Equals(value);
+            return (value / 2 * 2) == value;
         }
 
         /// <summary>

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Contents Managment/Extract content helper.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Contents Managment/Extract content helper.cs
@@ -8,13 +8,13 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
     internal class ExtractContentHelper
     {
         //ExStart:CommonExtractContent
-        public static ArrayList ExtractContent(Node startNode, Node endNode, bool isInclusive)
+        public static List<Node> ExtractContent(Node startNode, Node endNode, bool isInclusive)
         {
             // First, check that the nodes passed to this method are valid for use.
             VerifyParameterNodes(startNode, endNode);
 
             // Create a list to store the extracted nodes.
-            ArrayList nodes = new ArrayList();
+            List<Node> nodes = new List<Node>();
 
             // If either marker is part of a comment, including the comment itself, we need to move the pointer
             // forward to the Comment Node found after the CommentRangeEnd node.
@@ -97,10 +97,10 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
         }
         //ExEnd:CommonExtractContent
 
-        public static ArrayList ParagraphsByStyleName(Document doc, string styleName)
+        public static List<Paragraph> ParagraphsByStyleName(Document doc, string styleName)
         {
             // Create an array to collect paragraphs of the specified style.
-            ArrayList paragraphsWithStyle = new ArrayList();
+            List<Paragraph> paragraphsWithStyle = new List<Paragraph>();
             
             NodeCollection paragraphs = doc.GetChildNodes(NodeType.Paragraph, true);
             
@@ -115,7 +115,7 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
         }
 
         //ExStart:CommonGenerateDocument
-        public static Document GenerateDocument(Document srcDoc, ArrayList nodes)
+        public static Document GenerateDocument(Document srcDoc, List<Node> nodes)
         {
             Document dstDoc = new Document();
             // Remove the first paragraph from the empty document.
@@ -191,7 +191,7 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
                     !(node.NodeType == NodeType.Paragraph || node.NodeType == NodeType.Table));
         }
 
-        private static void ProcessMarker(Node cloneNode, ArrayList nodes, Node node, Node blockLevelAncestor,
+        private static void ProcessMarker(Node cloneNode, List<Node> nodes, Node node, Node blockLevelAncestor,
             bool isInclusive, bool isStartMarker, bool canAdd, bool forceAdd)
         {
             // If we are dealing with a block-level node, see if it should be included and add it to the list.
@@ -286,7 +286,7 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
             return list;
         }
 
-        private static void IncludeNextParagraph(Node node, ArrayList nodes)
+        private static void IncludeNextParagraph(Node node, List<Node> nodes)
         {
             Paragraph paragraph = (Paragraph) FindNextNode(NodeType.Paragraph, node.NextSibling);
             if (paragraph != null)

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Contents Managment/Extract content.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Contents Managment/Extract content.cs
@@ -324,7 +324,7 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
 
             foreach (Field field in doc.Range.Fields)
             {
-                if (field.Type.Equals(FieldType.FieldHyperlink))
+                if (field.Type == FieldType.FieldHyperlink)
                 {
                     FieldHyperlink hyperlink = (FieldHyperlink) field;
                     if (hyperlink.SubAddress != null && hyperlink.SubAddress.StartsWith("_Toc"))

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Contents Managment/Extract content.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Contents Managment/Extract content.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Text;
 using Aspose.Words;
 using Aspose.Words.Drawing;
@@ -21,7 +22,7 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
             Table endTable = (Table) doc.LastSection.GetChild(NodeType.Table, 0, true);
 
             // Extract the content between these nodes in the document. Include these markers in the extraction.
-            ArrayList extractedNodes = ExtractContentHelper.ExtractContent(startPara, endTable, true);
+            List<Node> extractedNodes = ExtractContentHelper.ExtractContent(startPara, endTable, true);
 
             // Let's reverse the array to make inserting the content back into the document easier.
             extractedNodes.Reverse();
@@ -54,13 +55,13 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
             BookmarkEnd bookmarkEnd = bookmark.BookmarkEnd;
 
             // Firstly, extract the content between these nodes, including the bookmark.
-            ArrayList extractedNodesInclusive = ExtractContentHelper.ExtractContent(bookmarkStart, bookmarkEnd, true);
+            List<Node> extractedNodesInclusive = ExtractContentHelper.ExtractContent(bookmarkStart, bookmarkEnd, true);
             
             Document dstDoc = ExtractContentHelper.GenerateDocument(doc, extractedNodesInclusive);
             dstDoc.Save(ArtifactsDir + "ExtractContent.ExtractContentBetweenBookmark.IncludingBookmark.docx");
 
             // Secondly, extract the content between these nodes this time without including the bookmark.
-            ArrayList extractedNodesExclusive = ExtractContentHelper.ExtractContent(bookmarkStart, bookmarkEnd, false);
+            List<Node> extractedNodesExclusive = ExtractContentHelper.ExtractContent(bookmarkStart, bookmarkEnd, false);
             
             dstDoc = ExtractContentHelper.GenerateDocument(doc, extractedNodesExclusive);
             dstDoc.Save(ArtifactsDir + "ExtractContent.ExtractContentBetweenBookmark.WithoutBookmark.docx");
@@ -79,13 +80,13 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
             CommentRangeEnd commentEnd = (CommentRangeEnd) doc.GetChild(NodeType.CommentRangeEnd, 0, true);
 
             // Firstly, extract the content between these nodes including the comment as well.
-            ArrayList extractedNodesInclusive = ExtractContentHelper.ExtractContent(commentStart, commentEnd, true);
+            List<Node> extractedNodesInclusive = ExtractContentHelper.ExtractContent(commentStart, commentEnd, true);
             
             Document dstDoc = ExtractContentHelper.GenerateDocument(doc, extractedNodesInclusive);
             dstDoc.Save(ArtifactsDir + "ExtractContent.ExtractContentBetweenCommentRange.IncludingComment.docx");
 
             // Secondly, extract the content between these nodes without the comment.
-            ArrayList extractedNodesExclusive = ExtractContentHelper.ExtractContent(commentStart, commentEnd, false);
+            List<Node> extractedNodesExclusive = ExtractContentHelper.ExtractContent(commentStart, commentEnd, false);
             
             dstDoc = ExtractContentHelper.GenerateDocument(doc, extractedNodesExclusive);
             dstDoc.Save(ArtifactsDir + "ExtractContent.ExtractContentBetweenCommentRange.WithoutComment.docx");
@@ -100,9 +101,9 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
 
             Paragraph startPara = (Paragraph) doc.FirstSection.Body.GetChild(NodeType.Paragraph, 6, true);
             Paragraph endPara = (Paragraph) doc.FirstSection.Body.GetChild(NodeType.Paragraph, 10, true);
-            
+
             // Extract the content between these nodes in the document. Include these markers in the extraction.
-            ArrayList extractedNodes = ExtractContentHelper.ExtractContent(startPara, endPara, true);
+            List<Node> extractedNodes = ExtractContentHelper.ExtractContent(startPara, endPara, true);
 
             Document dstDoc = ExtractContentHelper.GenerateDocument(doc, extractedNodes);
             dstDoc.Save(ArtifactsDir + "ExtractContent.ExtractContentBetweenParagraphs.docx");
@@ -116,15 +117,15 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
             Document doc = new Document(MyDir + "Extract content.docx");
 
             // Gather a list of the paragraphs using the respective heading styles.
-            ArrayList parasStyleHeading1 = ExtractContentHelper.ParagraphsByStyleName(doc, "Heading 1");
-            ArrayList parasStyleHeading3 = ExtractContentHelper.ParagraphsByStyleName(doc, "Heading 3");
+            List<Paragraph> parasStyleHeading1 = ExtractContentHelper.ParagraphsByStyleName(doc, "Heading 1");
+            List<Paragraph> parasStyleHeading3 = ExtractContentHelper.ParagraphsByStyleName(doc, "Heading 3");
 
             // Use the first instance of the paragraphs with those styles.
-            Node startPara1 = (Node) parasStyleHeading1[0];
-            Node endPara1 = (Node) parasStyleHeading3[0];
+            Node startPara1 = parasStyleHeading1[0];
+            Node endPara1 = parasStyleHeading3[0];
 
             // Extract the content between these nodes in the document. Don't include these markers in the extraction.
-            ArrayList extractedNodes = ExtractContentHelper.ExtractContent(startPara1, endPara1, false);
+            List<Node> extractedNodes = ExtractContentHelper.ExtractContent(startPara1, endPara1, false);
 
             Document dstDoc = ExtractContentHelper.GenerateDocument(doc, extractedNodes);
             dstDoc.Save(ArtifactsDir + "ExtractContent.ExtractContentBetweenParagraphStyles.docx");
@@ -143,7 +144,7 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
             Run endRun = para.Runs[4];
 
             // Extract the content between these nodes in the document. Include these markers in the extraction.
-            ArrayList extractedNodes = ExtractContentHelper.ExtractContent(startRun, endRun, true);
+            List<Node> extractedNodes = ExtractContentHelper.ExtractContent(startRun, endRun, true);
 
             Node node = (Node) extractedNodes[0];
             Console.WriteLine(node.ToString(SaveFormat.Text));
@@ -309,7 +310,7 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
             Paragraph endPara = (Paragraph) doc.FirstSection.GetChild(NodeType.Paragraph, 5, true);
 
             // Extract the content between these nodes in the document. Don't include these markers in the extraction.
-            ArrayList extractedNodes = ExtractContentHelper.ExtractContent(startField, endPara, false);
+            List<Node> extractedNodes = ExtractContentHelper.ExtractContent(startField, endPara, false);
 
             Document dstDoc = ExtractContentHelper.GenerateDocument(doc, extractedNodes);
             dstDoc.Save(ArtifactsDir + "ExtractContent.ExtractContentUsingField.docx");
@@ -369,13 +370,13 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
             const string paraStyle = "Heading 1";
             const string runStyle = "Intense Emphasis";
 
-            ArrayList paragraphs = ParagraphsByStyleName(doc, paraStyle);
+            List<Paragraph> paragraphs = ParagraphsByStyleName(doc, paraStyle);
             Console.WriteLine($"Paragraphs with \"{paraStyle}\" styles ({paragraphs.Count}):");
             
             foreach (Paragraph paragraph in paragraphs)
                 Console.Write(paragraph.ToString(SaveFormat.Text));
 
-            ArrayList runs = RunsByStyleName(doc, runStyle);
+            List<Run> runs = RunsByStyleName(doc, runStyle);
             Console.WriteLine($"\nRuns with \"{runStyle}\" styles ({runs.Count}):");
             
             foreach (Run run in runs)
@@ -384,9 +385,9 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
         }
 
         //ExStart:ParagraphsByStyleName
-        public ArrayList ParagraphsByStyleName(Document doc, string styleName)
+        public List<Paragraph> ParagraphsByStyleName(Document doc, string styleName)
         {
-            ArrayList paragraphsWithStyle = new ArrayList();
+            List<Paragraph> paragraphsWithStyle = new List<Paragraph>();
             NodeCollection paragraphs = doc.GetChildNodes(NodeType.Paragraph, true);
             
             foreach (Paragraph paragraph in paragraphs)
@@ -400,9 +401,9 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
         //ExEnd:ParagraphsByStyleName
         
         //ExStart:RunsByStyleName
-        public ArrayList RunsByStyleName(Document doc, string styleName)
+        public List<Run> RunsByStyleName(Document doc, string styleName)
         {
-            ArrayList runsWithStyle = new ArrayList();
+            List<Run> runsWithStyle = new List<Run>();
             NodeCollection runs = doc.GetChildNodes(NodeType.Run, true);
             
             foreach (Run run in runs)

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Contents Managment/Find and replace.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Contents Managment/Find and replace.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -67,7 +68,7 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
                     currentNode = SplitRun((Run) currentNode, e.MatchOffset);
 
                 // This array is used to store all nodes of the match for further highlighting.
-                ArrayList runs = new ArrayList();
+                List<Run> runs = new List<Run>();
 
                 // Find all runs that contain parts of the match string.
                 int remainingLength = e.Match.Value.Length;
@@ -76,7 +77,7 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
                     currentNode != null &&
                     currentNode.GetText().Length <= remainingLength)
                 {
-                    runs.Add(currentNode);
+                    runs.Add((Run) currentNode);
                     remainingLength -= currentNode.GetText().Length;
 
                     // Select the next Run node.
@@ -91,7 +92,7 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
                 if (currentNode != null && remainingLength > 0)
                 {
                     SplitRun((Run) currentNode, remainingLength);
-                    runs.Add(currentNode);
+                    runs.Add((Run) currentNode);
                 }
 
                 // Now highlight all runs in the sequence.
@@ -378,10 +379,10 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
 
             public ReplaceAction Replacing(ReplacingArgs args)
             {
-                ArrayList runs = FindAndSplitMatchRuns(args);
+                List<Run> runs = FindAndSplitMatchRuns(args);
 
                 DocumentBuilder builder = new DocumentBuilder((Document) args.MatchNode.Document);
-                builder.MoveTo((Run) runs[runs.Count - 1]);
+                builder.MoveTo(runs[runs.Count - 1]);
 
                 // Calculate the field's name from the FieldType enumeration by removing
                 // the first instance of "Field" from the text. This works for almost all of the field types.
@@ -398,9 +399,9 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
             }
 
             /// <summary>
-            /// Finds and splits the match runs and returns them in an ArrayList.
+            /// Finds and splits the match runs and returns them in an List.
             /// </summary>
-            public ArrayList FindAndSplitMatchRuns(ReplacingArgs args)
+            public List<Run> FindAndSplitMatchRuns(ReplacingArgs args)
             {
                 // This is a Run node that contains either the beginning or the complete match.
                 Node currentNode = args.MatchNode;
@@ -411,7 +412,7 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
                     currentNode = SplitRun((Run) currentNode, args.MatchOffset);
 
                 // This array is used to store all nodes of the match for further removing.
-                ArrayList runs = new ArrayList();
+                List<Run> runs = new List<Run>();
 
                 // Find all runs that contain parts of the match string.
                 int remainingLength = args.Match.Value.Length;
@@ -420,7 +421,7 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
                     currentNode != null &&
                     currentNode.GetText().Length <= remainingLength)
                 {
-                    runs.Add(currentNode);
+                    runs.Add((Run) currentNode);
                     remainingLength -= currentNode.GetText().Length;
 
                     do
@@ -433,7 +434,7 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
                 if (currentNode != null && remainingLength > 0)
                 {
                     SplitRun((Run) currentNode, remainingLength);
-                    runs.Add(currentNode);
+                    runs.Add((Run) currentNode);
                 }
 
                 return runs;

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Contents Managment/Find and replace.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Contents Managment/Find and replace.cs
@@ -237,7 +237,7 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
         [Test]
         public void IgnoreTextInsideInsertRevisions()
         {
-            // ExStart:IgnoreTextInsideInsertRevisions
+            //ExStart:IgnoreTextInsideInsertRevisions
             Document doc = new Document();
             DocumentBuilder builder = new DocumentBuilder(doc);
 
@@ -260,7 +260,7 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
             doc.Range.Replace(regex, "*", options);
             
             Console.WriteLine(doc.GetText());
-            // ExEnd:IgnoreTextInsideInsertRevisions
+            //ExEnd:IgnoreTextInsideInsertRevisions
         }
 
         [Test]
@@ -352,7 +352,7 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
 
             private readonly StringBuilder mTextBuilder = new StringBuilder();
         }
-        // ExEnd:ShowChangesForHeaderAndFooterOrders
+        //ExEnd:ShowChangesForHeaderAndFooterOrders
 
         [Test]
         public void ReplaceTextWithField()
@@ -496,7 +496,7 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
         //ExEnd:MyReplaceEvaluator
 
         [Test]
-        // ExStart:ReplaceWithHtml
+        //ExStart:ReplaceWithHtml
         public void ReplaceWithHtml()
         {
             Document doc = new Document();

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Contents Managment/Remove content.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Contents Managment/Remove content.cs
@@ -12,9 +12,9 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
         [Test]
         public void RemovePageBreaks()
         {
-            // ExStart:OpenFromFile
+            //ExStart:OpenFromFile
             Document doc = new Document(MyDir + "Document.docx");
-            // ExEnd:OpenFromFile
+            //ExEnd:OpenFromFile
 
             // In Aspose.Words section breaks are represented as separate Section nodes in the document.
             // To remove these separate sections, the sections are combined.

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Contents Managment/Remove content.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Contents Managment/Remove content.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using Aspose.Words;
 using Aspose.Words.Fields;
 using NUnit.Framework;
@@ -103,9 +104,9 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
         public void RemoveTableOfContents(Document doc, int index)
         {
             // Store the FieldStart nodes of TOC fields in the document for quick access.
-            ArrayList fieldStarts = new ArrayList();
+            List<FieldStart> fieldStarts = new List<FieldStart>();
             // This is a list to store the nodes found inside the specified TOC. They will be removed at the end of this method.
-            ArrayList nodeList = new ArrayList();
+            List<Node> nodeList = new List<Node>();
 
             foreach (FieldStart start in doc.GetChildNodes(NodeType.FieldStart, true))
             {
@@ -121,7 +122,7 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
 
             bool isRemoving = true;
             
-            Node currentNode = (Node) fieldStarts[index];
+            Node currentNode = fieldStarts[index];
             while (isRemoving)
             {
                 // It is safer to store these nodes and delete them all at once later.

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Contents Managment/Working with Bookmarks.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Contents Managment/Working with Bookmarks.cs
@@ -203,7 +203,7 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
             while (currentNode != null && flag)
             {
                 if (currentNode.NodeType == NodeType.Run)
-                    if (currentNode.ToString(SaveFormat.Text).Trim().Equals("\""))
+                    if (currentNode.ToString(SaveFormat.Text).Trim() == "\"")
                         flag = false;
 
                 Node nextNode = currentNode.NextSibling;

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Contents Managment/Working with SDT.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Contents Managment/Working with SDT.cs
@@ -228,20 +228,20 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
         [Test]
         public void MultiSection()
         {
-            // ExStart:MultiSectionSDT
+            //ExStart:MultiSectionSDT
             Document doc = new Document(MyDir + "Multi-section structured document tags.docx");
 
             NodeCollection tags = doc.GetChildNodes(NodeType.StructuredDocumentTagRangeStart, true);
 
             foreach (StructuredDocumentTagRangeStart tag in tags)
                 Console.WriteLine(tag.Title);
-            // ExEnd:MultiSectionSDT
+            //ExEnd:MultiSectionSDT
         }
 
         [Test]
         public void StructuredDocumentTagRangeStartXmlMapping()
         {
-            // ExStart:StructuredDocumentTagRangeStartXmlMapping
+            //ExStart:StructuredDocumentTagRangeStartXmlMapping
             Document doc = new Document(MyDir + "Multi-section structured document tags.docx");
 
             // Construct an XML part that contains data and add it to the document's CustomXmlPart collection.
@@ -259,7 +259,7 @@ namespace DocsExamples.Programming_with_Documents.Contents_Managment
             sdtRangeStart.XmlMapping.SetMapping(xmlPart, "/root[1]/text[2]", null);
 
             doc.Save(ArtifactsDir + "WorkingWithSdt.StructuredDocumentTagRangeStartXmlMapping.docx");
-            // ExEnd:StructuredDocumentTagRangeStartXmlMapping
+            //ExEnd:StructuredDocumentTagRangeStartXmlMapping
         }
     }
 }

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Protect or Encrypt Document/Document protection.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Protect or Encrypt Document/Document protection.cs
@@ -17,10 +17,10 @@ namespace DocsExamples.Programming_with_Documents.Protect_or_Encrypt_Document
         [Test]
         public void Unprotect()
         {
-            // ExStart:UnprotectDocument
+            //ExStart:UnprotectDocument
             Document doc = new Document(MyDir + "Document.docx");
             doc.Unprotect();
-            // ExEnd:UnprotectDocument
+            //ExEnd:UnprotectDocument
         }
 
         [Test]

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Split Documents/Page splitter.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Split Documents/Page splitter.cs
@@ -698,7 +698,7 @@ namespace DocsExamples.Programming_with_Documents.Split_Documents
         public void RemovePageBreakFromParagraph(Paragraph paragraph)
         {
             Run run = (Run) paragraph.FirstChild;
-            if (run.Text.Equals(PageBreakStr))
+            if (run.Text == PageBreakStr)
             {
                 paragraph.RemoveChild(run);
             }
@@ -720,7 +720,7 @@ namespace DocsExamples.Programming_with_Documents.Split_Documents
         {
             Paragraph paragraph = run.ParentParagraph;
             
-            if (run.Text.Equals(PageBreakStr))
+            if (run.Text == PageBreakStr)
             {
                 paragraph.RemoveChild(run);
             }

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Split Documents/Split into html pages.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Split Documents/Split into html pages.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using Aspose.Words;
@@ -39,9 +40,9 @@ namespace DocsExamples.Programming_with_Documents.Split_Documents
             mTocTemplate = tocTemplate;
             mDstDir = dstDir;
 
-            ArrayList topicStartParas = SelectTopicStarts();
+            List<Paragraph> topicStartParas = SelectTopicStarts();
             InsertSectionBreaks(topicStartParas);
-            ArrayList topics = SaveHtmlTopics();
+            List<Topic> topics = SaveHtmlTopics();
             SaveTableOfContents(topics);
         }
 
@@ -49,10 +50,10 @@ namespace DocsExamples.Programming_with_Documents.Split_Documents
         /// Selects heading paragraphs that must become topic starts.
         /// We can't modify them in this loop, so we need to remember them in an array first.
         /// </summary>
-        private ArrayList SelectTopicStarts()
+        private List<Paragraph> SelectTopicStarts()
         {
             NodeCollection paras = mDoc.GetChildNodes(NodeType.Paragraph, true);
-            ArrayList topicStartParas = new ArrayList();
+            List<Paragraph> topicStartParas = new List<Paragraph>();
 
             foreach (Paragraph para in paras)
             {
@@ -67,7 +68,7 @@ namespace DocsExamples.Programming_with_Documents.Split_Documents
         /// <summary>
         /// Insert section breaks before the specified paragraphs.
         /// </summary>
-        private void InsertSectionBreaks(ArrayList topicStartParas)
+        private void InsertSectionBreaks(List<Paragraph> topicStartParas)
         {
             DocumentBuilder builder = new DocumentBuilder(mDoc);
             foreach (Paragraph para in topicStartParas)
@@ -91,9 +92,9 @@ namespace DocsExamples.Programming_with_Documents.Split_Documents
         /// Splits the current document into one topic per section and saves each topic
         /// as an HTML file. Returns a collection of Topic objects.
         /// </summary>
-        private ArrayList SaveHtmlTopics()
+        private List<Topic> SaveHtmlTopics()
         {
-            ArrayList topics = new ArrayList();
+            List<Topic> topics = new List<Topic>();
             for (int sectionIdx = 0; sectionIdx < mDoc.Sections.Count; sectionIdx++)
             {
                 Section section = mDoc.Sections[sectionIdx];
@@ -172,7 +173,7 @@ namespace DocsExamples.Programming_with_Documents.Split_Documents
         /// <summary>
         /// Generates a table of contents for the topics and saves to contents .html.
         /// </summary>
-        private void SaveTableOfContents(ArrayList topics)
+        private void SaveTableOfContents(List<Topic> topics)
         {
             Document tocDoc = new Document(mTocTemplate);
 
@@ -229,7 +230,7 @@ namespace DocsExamples.Programming_with_Documents.Split_Documents
 
     internal class TocMailMergeDataSource : IMailMergeDataSource
     {
-        internal TocMailMergeDataSource(ArrayList topics)
+        internal TocMailMergeDataSource(List<Topic> topics)
         {
             mTopics = topics;
             mIndex = -1;
@@ -266,7 +267,7 @@ namespace DocsExamples.Programming_with_Documents.Split_Documents
             return null;
         }
 
-        private readonly ArrayList mTopics;
+        private readonly List<Topic> mTopics;
         private int mIndex;
     }
 }

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Comments.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Comments.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using Aspose.Words;
 using NUnit.Framework;
 
@@ -109,9 +110,9 @@ namespace DocsExamples.Programming_with_Documents
         }
 
         //ExStart:ExtractComments
-        ArrayList ExtractComments(Document doc)
+        List<string> ExtractComments(Document doc)
         {
-            ArrayList collectedComments = new ArrayList();
+            List<string> collectedComments = new List<string>();
             NodeCollection comments = doc.GetChildNodes(NodeType.Comment, true);
 
             foreach (Comment comment in comments)
@@ -125,9 +126,9 @@ namespace DocsExamples.Programming_with_Documents
         //ExEnd:ExtractComments
 
         //ExStart:ExtractCommentsByAuthor
-        ArrayList ExtractComments(Document doc, string authorName)
+        List<string> ExtractComments(Document doc, string authorName)
         {
-            ArrayList collectedComments = new ArrayList();
+            List<string> collectedComments = new List<string>();
             NodeCollection comments = doc.GetChildNodes(NodeType.Comment, true);
 
             foreach (Comment comment in comments)

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Comments.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Comments.cs
@@ -83,7 +83,7 @@ namespace DocsExamples.Programming_with_Documents
         [Test]
         public void ProcessComments()
         {
-            // ExStart:ProcessComments
+            //ExStart:ProcessComments
             Document doc = new Document(MyDir + "Comments.docx");
 
             // Extract the information about the comments of all the authors.

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Document/Clone and combine documents.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Document/Clone and combine documents.cs
@@ -81,7 +81,7 @@ namespace DocsExamples.Programming_with_Documents.Working_with_Document
         //ExStart:InsertDocument
         private static void InsertDocument(Node insertionDestination, Document docToInsert)
         {
-            if (insertionDestination.NodeType.Equals(NodeType.Paragraph) || insertionDestination.NodeType.Equals(NodeType.Table))
+            if (insertionDestination.NodeType == NodeType.Paragraph || insertionDestination.NodeType == NodeType.Table)
             {
                 CompositeNode destinationParent = insertionDestination.ParentNode;
 
@@ -93,7 +93,7 @@ namespace DocsExamples.Programming_with_Documents.Working_with_Document
                 foreach (Section srcSection in docToInsert.Sections.OfType<Section>())
                 foreach (Node srcNode in srcSection.Body)
                 {
-                    if (srcNode.NodeType.Equals(NodeType.Paragraph))
+                    if (srcNode.NodeType == NodeType.Paragraph)
                     {
                         Paragraph para = (Paragraph)srcNode;
                         if (para.IsEndOfSection && !para.HasChildNodes)
@@ -122,8 +122,8 @@ namespace DocsExamples.Programming_with_Documents.Working_with_Document
         /// <param name="srcDoc">The document to insert.</param>
         void InsertDocumentWithSectionFormatting(Node insertAfterNode, Document srcDoc)
         {
-            if (!insertAfterNode.NodeType.Equals(NodeType.Paragraph) &
-                !insertAfterNode.NodeType.Equals(NodeType.Table))
+            if (insertAfterNode.NodeType != NodeType.Paragraph &&
+                insertAfterNode.NodeType != NodeType.Table)
                 throw new ArgumentException("The destination node should be either a paragraph or table.");
 
             Document dstDoc = (Document) insertAfterNode.Document;

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Document/Compare documents.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Document/Compare documents.cs
@@ -62,7 +62,7 @@ namespace DocsExamples.Programming_with_Documents.Working_with_Document
         [Test]
         public void ComparisonGranularity()
         {
-            // ExStart:ComparisonGranularity
+            //ExStart:ComparisonGranularity
             DocumentBuilder builderA = new DocumentBuilder(new Document());
             DocumentBuilder builderB = new DocumentBuilder(new Document());
 
@@ -72,7 +72,7 @@ namespace DocsExamples.Programming_with_Documents.Working_with_Document
             CompareOptions compareOptions = new CompareOptions { Granularity = Granularity.CharLevel };
 
             builderA.Document.Compare(builderB.Document, "author", DateTime.Now, compareOptions);
-            // ExEnd:ComparisonGranularity      
+            //ExEnd:ComparisonGranularity      
         }
     }
 }

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Document/Join and append documents.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Document/Join and append documents.cs
@@ -540,7 +540,7 @@ namespace DocsExamples.Programming_with_Documents.Working_with_Document
         [Test]
         public void IgnoreHeaderFooter()
         {
-            // ExStart:IgnoreHeaderFooter
+            //ExStart:IgnoreHeaderFooter
             Document srcDocument = new Document(MyDir + "Document source.docx");
             Document dstDocument = new Document(MyDir + "Northwind traders.docx");
 
@@ -549,7 +549,7 @@ namespace DocsExamples.Programming_with_Documents.Working_with_Document
             dstDocument.AppendDocument(srcDocument, ImportFormatMode.KeepSourceFormatting, importFormatOptions);
             
             dstDocument.Save(ArtifactsDir + "JoinAndAppendDocuments.IgnoreHeaderFooter.docx");
-            // ExEnd:IgnoreHeaderFooter
+            //ExEnd:IgnoreHeaderFooter
         }
 
         [Test]

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Document/Join and append documents.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Document/Join and append documents.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
 using System.Text;
 using Aspose.Words;
 using Aspose.Words.Fields;
@@ -363,7 +364,7 @@ namespace DocsExamples.Programming_with_Documents.Working_with_Document
             srcDoc.FirstSection.PageSetup.SectionStart = SectionStart.Continuous;
 
             // Keep track of the lists that are created.
-            Hashtable newLists = new Hashtable();
+            Dictionary<int, Aspose.Words.Lists.List> newLists = new Dictionary<int, Aspose.Words.Lists.List>();
 
             foreach (Paragraph para in srcDoc.GetChildNodes(NodeType.Paragraph, true))
             {
@@ -378,9 +379,9 @@ namespace DocsExamples.Programming_with_Documents.Working_with_Document
                         Aspose.Words.Lists.List currentList;
                         // A newly copied list already exists for this ID, retrieve the stored list,
                         // and use it on the current paragraph.
-                        if (newLists.Contains(listId))
+                        if (newLists.ContainsKey(listId))
                         {
-                            currentList = (Aspose.Words.Lists.List) newLists[listId];
+                            currentList = newLists[listId];
                         }
                         else
                         {

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Document/Working with document options and settings.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Document/Working with document options and settings.cs
@@ -22,20 +22,20 @@ namespace DocsExamples.Programming_with_Documents.Working_with_Document
         [Test]
         public void ShowGrammaticalAndSpellingErrors()
         {
-            // ExStart:ShowGrammaticalAndSpellingErrors
+            //ExStart:ShowGrammaticalAndSpellingErrors
             Document doc = new Document(MyDir + "Document.docx");
 
             doc.ShowGrammaticalErrors = true;
             doc.ShowSpellingErrors = true;
 
             doc.Save(ArtifactsDir + "WorkingWithDocumentOptionsAndSettings.ShowGrammaticalAndSpellingErrors.docx");
-            // ExEnd:ShowGrammaticalAndSpellingErrors
+            //ExEnd:ShowGrammaticalAndSpellingErrors
         }
 
         [Test]
         public void CleanupUnusedStylesAndLists()
         {
-            // ExStart:CleanupUnusedStylesandLists
+            //ExStart:CleanupUnusedStylesandLists
             Document doc = new Document(MyDir + "Document.docx");
 
             CleanupOptions cleanupOptions = new CleanupOptions { UnusedLists = false, UnusedStyles = true };
@@ -44,13 +44,13 @@ namespace DocsExamples.Programming_with_Documents.Working_with_Document
             doc.Cleanup(cleanupOptions);
 
             doc.Save(ArtifactsDir + "WorkingWithDocumentOptionsAndSettings.CleanupUnusedStylesAndLists.docx");
-            // ExEnd:CleanupUnusedStylesandLists
+            //ExEnd:CleanupUnusedStylesandLists
         }
 
         [Test]
         public void CleanupDuplicateStyle()
         {
-            // ExStart:CleanupDuplicateStyle
+            //ExStart:CleanupDuplicateStyle
             Document doc = new Document(MyDir + "Document.docx");
 
             CleanupOptions options = new CleanupOptions { DuplicateStyle = true };
@@ -59,7 +59,7 @@ namespace DocsExamples.Programming_with_Documents.Working_with_Document
             doc.Cleanup(options);
 
             doc.Save(ArtifactsDir + "WorkingWithDocumentOptionsAndSettings.CleanupDuplicateStyle.docx");
-            // ExEnd:CleanupDuplicateStyle
+            //ExEnd:CleanupDuplicateStyle
         }
 
         [Test]

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Fields.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Fields.cs
@@ -87,7 +87,7 @@ namespace DocsExamples.Programming_with_Documents
             NodeCollection fieldStarts = doc.GetChildNodes(NodeType.FieldStart, true);
             foreach (FieldStart fieldStart in fieldStarts)
             {
-                if (fieldStart.FieldType.Equals(FieldType.FieldMergeField))
+                if (fieldStart.FieldType == FieldType.FieldMergeField)
                 {
                     MergeField mergeField = new MergeField(fieldStart);
                     mergeField.Name += "_Renamed";
@@ -106,9 +106,9 @@ namespace DocsExamples.Programming_with_Documents
         {
             internal MergeField(FieldStart fieldStart)
             {
-                if (fieldStart.Equals(null))
+                if (fieldStart == null)
                     throw new ArgumentNullException(nameof(fieldStart));
-                if (!fieldStart.FieldType.Equals(FieldType.FieldMergeField))
+                if (fieldStart.FieldType != FieldType.FieldMergeField)
                     throw new ArgumentException("Field start type must be FieldMergeField.");
 
                 mFieldStart = fieldStart;

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Fields.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Fields.cs
@@ -195,7 +195,7 @@ namespace DocsExamples.Programming_with_Documents
         [Test]
         public void InsertTOAFieldWithoutDocumentBuilder()
         {
-            // ExStart:InsertTOAFieldWithoutDocumentBuilder
+            //ExStart:InsertTOAFieldWithoutDocumentBuilder
             Document doc = new Document();
             Paragraph para = new Paragraph(doc);
 
@@ -224,7 +224,7 @@ namespace DocsExamples.Programming_with_Documents
         [Test]
         public void InsertNestedFields()
         {
-            // ExStart:InsertNestedFields
+            //ExStart:InsertNestedFields
             Document doc = new Document();
             DocumentBuilder builder = new DocumentBuilder(doc);
 
@@ -375,7 +375,7 @@ namespace DocsExamples.Programming_with_Documents
         [Test]
         public void InsertAuthorField()
         {
-            // ExStart:InsertAuthorField
+            //ExStart:InsertAuthorField
             Document doc = new Document();
 
             Paragraph para = (Paragraph) doc.GetChildNodes(NodeType.Paragraph, true)[0];

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Fonts.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Fonts.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Reflection;
@@ -203,8 +204,8 @@ namespace DocsExamples.Programming_with_Documents
             FontSettings fontSettings = new FontSettings();
             // Retrieve the array of environment-dependent font sources that are searched by default.
             // For example this will contain a "Windows\Fonts\" source on a Windows machines.
-            // We add this array to a new ArrayList to make adding or removing font entries much easier.
-            ArrayList fontSources = new ArrayList(fontSettings.GetFontsSources());
+            // We add this array to a new List to make adding or removing font entries much easier.
+            List<FontSourceBase> fontSources = new List<FontSourceBase>(fontSettings.GetFontsSources());
 
             // Add a new folder source which will instruct Aspose.Words to search the following folder for fonts.
             FolderFontSource folderFontSource = new FolderFontSource("C:\\MyFonts\\", true);
@@ -212,7 +213,7 @@ namespace DocsExamples.Programming_with_Documents
             // Add the custom folder which contains our fonts to the list of existing font sources.
             fontSources.Add(folderFontSource);
 
-            FontSourceBase[] updatedFontSources = (FontSourceBase[]) fontSources.ToArray(typeof(FontSourceBase));
+            FontSourceBase[] updatedFontSources = fontSources.ToArray();
             fontSettings.SetFontsSources(updatedFontSources);
             
             doc.FontSettings = fontSettings;
@@ -336,14 +337,14 @@ namespace DocsExamples.Programming_with_Documents
         {
             //ExStart:GetListOfAvailableFonts
             FontSettings fontSettings = new FontSettings();
-            ArrayList fontSources = new ArrayList(fontSettings.GetFontsSources());
+            List<FontSourceBase> fontSources = new List<FontSourceBase>(fontSettings.GetFontsSources());
 
             // Add a new folder source which will instruct Aspose.Words to search the following folder for fonts.
             FolderFontSource folderFontSource = new FolderFontSource(MyDir, true);
             // Add the custom folder which contains our fonts to the list of existing font sources.
             fontSources.Add(folderFontSource);
 
-            FontSourceBase[] updatedFontSources = (FontSourceBase[]) fontSources.ToArray(typeof(FontSourceBase));
+            FontSourceBase[] updatedFontSources = fontSources.ToArray();
 
             foreach (PhysicalFontInfo fontInfo in updatedFontSources[0].GetAvailableFonts())
             {
@@ -447,12 +448,12 @@ namespace DocsExamples.Programming_with_Documents
             DocumentSubstitutionWarnings substitutionWarningHandler = new DocumentSubstitutionWarnings();
             doc.WarningCallback = substitutionWarningHandler;
 
-            ArrayList fontSources = new ArrayList(FontSettings.DefaultInstance.GetFontsSources());
+            List<FontSourceBase> fontSources = new List<FontSourceBase>(FontSettings.DefaultInstance.GetFontsSources());
 
             FolderFontSource folderFontSource = new FolderFontSource(FontsDir, true);
             fontSources.Add(folderFontSource);
 
-            FontSourceBase[] updatedFontSources = (FontSourceBase[])fontSources.ToArray(typeof(FontSourceBase));
+            FontSourceBase[] updatedFontSources = fontSources.ToArray();
             FontSettings.DefaultInstance.SetFontsSources(updatedFontSources);
 
             doc.Save(ArtifactsDir + "WorkingWithFonts.GetSubstitutionWithoutSuffixes.pdf");

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Fonts.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Fonts.cs
@@ -91,7 +91,7 @@ namespace DocsExamples.Programming_with_Documents
         [Test]
         public void SetFontEmphasisMark()
         {
-            // ExStart:SetFontEmphasisMark
+            //ExStart:SetFontEmphasisMark
             Document document = new Document();
             DocumentBuilder builder = new DocumentBuilder(document);
 
@@ -103,13 +103,13 @@ namespace DocsExamples.Programming_with_Documents
             builder.Write("Simple text");
 
             document.Save(ArtifactsDir + "WorkingWithFonts.SetFontEmphasisMark.docx");
-            // ExEnd:SetFontEmphasisMark
+            //ExEnd:SetFontEmphasisMark
         }
 
         [Test]
         public void SetFontsFolders()
         {
-            // ExStart:SetFontsFolders
+            //ExStart:SetFontsFolders
             FontSettings.DefaultInstance.SetFontsSources(new FontSourceBase[]
             {
                 new SystemFontSource(), new FolderFontSource("C:\\MyFonts\\", true)
@@ -117,7 +117,7 @@ namespace DocsExamples.Programming_with_Documents
 
             Document doc = new Document(MyDir + "Rendering.docx");
             doc.Save(ArtifactsDir + "WorkingWithFonts.SetFontsFolders.pdf");
-            // ExEnd:SetFontsFolders           
+            //ExEnd:SetFontsFolders           
         }
 
         [Test]
@@ -169,9 +169,9 @@ namespace DocsExamples.Programming_with_Documents
         [Test]
         public void SetFontsFoldersDefaultInstance()
         {
-            // ExStart:SetFontsFoldersDefaultInstance
+            //ExStart:SetFontsFoldersDefaultInstance
             FontSettings.DefaultInstance.SetFontsFolder("C:\\MyFonts\\", true);
-            // ExEnd:SetFontsFoldersDefaultInstance           
+            //ExEnd:SetFontsFoldersDefaultInstance           
 
             Document doc = new Document(MyDir + "Rendering.docx");
             doc.Save(ArtifactsDir + "WorkingWithFonts.SetFontsFoldersDefaultInstance.pdf");
@@ -225,12 +225,12 @@ namespace DocsExamples.Programming_with_Documents
         [Test]
         public void SetFontsFoldersWithPriority()
         {
-            // ExStart:SetFontsFoldersWithPriority
+            //ExStart:SetFontsFoldersWithPriority
             FontSettings.DefaultInstance.SetFontsSources(new FontSourceBase[]
             {
                 new SystemFontSource(), new FolderFontSource("C:\\MyFonts\\", true,1)
             });
-            // ExEnd:SetFontsFoldersWithPriority           
+            //ExEnd:SetFontsFoldersWithPriority           
 
             Document doc = new Document(MyDir + "Rendering.docx");
             doc.Save(ArtifactsDir + "WorkingWithFonts.SetFontsFoldersWithPriority.pdf");
@@ -305,27 +305,27 @@ namespace DocsExamples.Programming_with_Documents
         [Test]
         public void FontSettingsWithLoadOption()
         {
-            // ExStart:FontSettingsWithLoadOption
+            //ExStart:FontSettingsWithLoadOption
             LoadOptions loadOptions = new LoadOptions();
             loadOptions.FontSettings = new FontSettings();
 
             Document doc = new Document(MyDir + "Rendering.docx", loadOptions);
-            // ExEnd:FontSettingsWithLoadOption   
+            //ExEnd:FontSettingsWithLoadOption   
         }
 
         [Test]
         public void FontSettingsDefaultInstance()
         {
-            // ExStart:FontSettingsFontSource
-            // ExStart:FontSettingsDefaultInstance
+            //ExStart:FontSettingsFontSource
+            //ExStart:FontSettingsDefaultInstance
             FontSettings fontSettings = FontSettings.DefaultInstance;
-            // ExEnd:FontSettingsDefaultInstance   
+            //ExEnd:FontSettingsDefaultInstance   
             fontSettings.SetFontsSources(new FontSourceBase[]
             {
                 new SystemFontSource(),
                 new FolderFontSource("C:\\MyFonts\\", true)
             });
-            // ExEnd:FontSettingsFontSource
+            //ExEnd:FontSettingsFontSource
 
             LoadOptions loadOptions = new LoadOptions();
             loadOptions.FontSettings = fontSettings;
@@ -418,7 +418,7 @@ namespace DocsExamples.Programming_with_Documents
         }
         //ExEnd:HandleDocumentWarnings
 
-        // ExStart:ResourceSteamFontSourceExample
+        //ExStart:ResourceSteamFontSourceExample
         [Test]
         public void ResourceSteamFontSourceExample()
         {
@@ -437,7 +437,7 @@ namespace DocsExamples.Programming_with_Documents
                 return Assembly.GetExecutingAssembly().GetManifestResourceStream("resourceName");
             }
         }
-        // ExEnd:ResourceSteamFontSourceExample
+        //ExEnd:ResourceSteamFontSourceExample
 
         //ExStart:GetSubstitutionWithoutSuffixes
         [Test]

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with FormFields.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with FormFields.cs
@@ -26,7 +26,7 @@ namespace DocsExamples.Programming_with_Documents
             Document doc = new Document(MyDir + "Form fields.docx");
             FormField formField = doc.Range.FormFields[3];
 
-            if (formField.Type.Equals(FieldType.FieldFormTextInput))
+            if (formField.Type == FieldType.FieldFormTextInput)
                 formField.Result = "My name is " + formField.Name;
             //ExEnd:FormFieldsWorkWithProperties            
         }

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Graphic Elements/Working with Charts.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Graphic Elements/Working with Charts.cs
@@ -294,7 +294,7 @@ namespace DocsExamples.Programming_with_Documents.Working_with_Graphic_Elements
             chart.AxisY.Scaling.Maximum = new AxisBound(6);
 
             doc.Save(ArtifactsDir + "WorkingWithCharts.BoundsOfAxis.docx");
-            // ExEnd:SetboundsOfAxis
+            //ExEnd:SetboundsOfAxis
         }
 
         [Test]

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Graphic Elements/Working with Images.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Graphic Elements/Working with Images.cs
@@ -215,7 +215,7 @@ namespace DocsExamples.Programming_with_Documents.Working_with_Graphic_Elements
 
             // Ignore metafiles, they are vector drawings, and we don't want to resample them.
             ImageType imageType = imageData.ImageType;
-            if (imageType.Equals(ImageType.Wmf) || imageType.Equals(ImageType.Emf))
+            if (imageType == ImageType.Wmf || imageType == ImageType.Emf)
                 return false;
 
             try

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with List.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with List.cs
@@ -70,7 +70,7 @@ namespace DocsExamples.Programming_with_Documents
             builder.ListFormat.List = null;
 
             builder.Document.Save(ArtifactsDir + "WorkingWithList.SpecifyListLevel.docx");
-            // ExEnd:SpecifyListLevel
+            //ExEnd:SpecifyListLevel
         }
 
         [Test]

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Node.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Node.cs
@@ -69,7 +69,7 @@ namespace DocsExamples.Programming_with_Documents
             foreach (Node child in children)
             {
                 // A paragraph may contain children of various types such as runs, shapes, and others.
-                if (child.NodeType.Equals(NodeType.Run))
+                if (child.NodeType == NodeType.Run)
                 {
                     Run run = (Run) child;
                     Console.WriteLine(run.Text);

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Tables/Working with Tables.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Tables/Working with Tables.cs
@@ -74,7 +74,7 @@ namespace DocsExamples.Programming_with_Documents.Working_with_Tables
             /// <summary>
             /// Returns the cells which make up the column.
             /// </summary>
-            public Cell[] Cells => (Cell[]) GetColumnCells().ToArray(typeof(Cell));
+            public Cell[] Cells => GetColumnCells().ToArray();
 
             /// <summary>
             /// Returns the index of the given cell in the column.
@@ -136,9 +136,9 @@ namespace DocsExamples.Programming_with_Documents.Working_with_Tables
             /// <summary>
             /// Provides an up-to-date collection of cells which make up the column represented by this facade.
             /// </summary>
-            private ArrayList GetColumnCells()
+            private List<Cell> GetColumnCells()
             {
-                ArrayList columnCells = new ArrayList();
+                List<Cell> columnCells = new List<Cell>();
 
                 foreach (Row row in mTable.Rows)
                 {

--- a/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Tables/Working with Tables.cs
+++ b/Examples/DocsExamples/DocsExamples/Programming with Documents/Working with Tables/Working with Tables.cs
@@ -185,7 +185,7 @@ namespace DocsExamples.Programming_with_Documents.Working_with_Tables
         [Test]
         public void AutoFitTableToPageWidth()
         {
-            // ExStart:AutoFitTableToPageWidth
+            //ExStart:AutoFitTableToPageWidth
             Document doc = new Document(MyDir + "Tables.docx");
 
             Table table = (Table) doc.GetChild(NodeType.Table, 0, true);
@@ -1120,7 +1120,7 @@ namespace DocsExamples.Programming_with_Documents.Working_with_Tables
         [Test]
         public void SetRelativeHorizontalOrVerticalPosition()
         {
-            // ExStart:SetRelativeHorizontalOrVerticalPosition
+            //ExStart:SetRelativeHorizontalOrVerticalPosition
             Document doc = new Document(MyDir + "Table wrapped by text.docx");
 
             Table table = doc.FirstSection.Body.Tables[0];
@@ -1128,7 +1128,7 @@ namespace DocsExamples.Programming_with_Documents.Working_with_Tables
             table.VerticalAnchor = RelativeVerticalPosition.Page;
 
             doc.Save(ArtifactsDir + "WorkingWithTables.SetFloatingTablePosition.docx");
-            // ExEnd:SetRelativeHorizontalOrVerticalPosition
+            //ExEnd:SetRelativeHorizontalOrVerticalPosition
         }
     }
 }

--- a/Examples/DocsExamples/DocsExamples/Rendering and Printing/Print documents.cs
+++ b/Examples/DocsExamples/DocsExamples/Rendering and Printing/Print documents.cs
@@ -56,7 +56,7 @@ namespace DocsExamples.Rendering_and_Printing
             //ExEnd:PrintDialog
 
             //ExStart:ShowDialog
-            if (!printDlg.ShowDialog().Equals(DialogResult.OK))
+            if (printDlg.ShowDialog() != DialogResult.OK)
                 return;
             //ExEnd:ShowDialog
 
@@ -103,7 +103,7 @@ namespace DocsExamples.Rendering_and_Printing
 
             // Check if the user accepted the print settings and proceed to preview.
             //ExStart:CheckPrintSettings
-            if (!printDlg.ShowDialog().Equals(DialogResult.OK))
+            if (printDlg.ShowDialog() != DialogResult.OK)
                 return;
             //ExEnd:CheckPrintSettings
 

--- a/Examples/DocsExamples/DocsExamples/Rendering and Printing/Print documents.cs
+++ b/Examples/DocsExamples/DocsExamples/Rendering and Printing/Print documents.cs
@@ -53,7 +53,7 @@ namespace DocsExamples.Rendering_and_Printing
                     MinimumPage = 1, MaximumPage = doc.PageCount, FromPage = 1, ToPage = doc.PageCount
                 }
             };
-            // ExEnd:PrintDialog
+            //ExEnd:PrintDialog
 
             //ExStart:ShowDialog
             if (!printDlg.ShowDialog().Equals(DialogResult.OK))

--- a/Examples/DocsExamples/DocumentExplorer/Item.cs
+++ b/Examples/DocsExamples/DocumentExplorer/Item.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Reflection;
@@ -208,7 +209,7 @@ namespace DocumentExplorer
         static Item()
         {
             // Fill set of typenames of Item inheritors for Item class fabric.
-            gItemSet = new ArrayList();
+            gItemSet = new List<string>();
             foreach (Type type in Assembly.GetExecutingAssembly().GetTypes()) 
             {
                 if (type.IsSubclassOf(typeof(Item)) && !type.IsAbstract) 
@@ -250,8 +251,8 @@ namespace DocumentExplorer
         private static ImageList mImageList;
         private Icon mIcon;
 
-        private static readonly ArrayList gItemSet;
-        private static readonly ArrayList gIconNames = new ArrayList();
+        private static readonly List<string> gItemSet;
+        private static readonly List<string> gIconNames = new List<string>();
         /// <summary>
         /// Map of character to string that we use to display control MS Word control characters.
         /// </summary>

--- a/Examples/DocsExamples/DocumentExplorer/Item.cs
+++ b/Examples/DocsExamples/DocumentExplorer/Item.cs
@@ -53,7 +53,7 @@ namespace DocumentExplorer
                 // E.g. [!PageBreak!], [!ParagraphBreak!], etc.
                 foreach (char c in mNode.GetText())
                 {
-                    string controlCharDisplay = (string)gControlCharacters[c];
+                    string controlCharDisplay = gControlCharacters[c];
                     if (controlCharDisplay == null)
                         result.Append(c);
                     else 
@@ -209,7 +209,6 @@ namespace DocumentExplorer
         static Item()
         {
             // Fill set of typenames of Item inheritors for Item class fabric.
-            gItemSet = new List<string>();
             foreach (Type type in Assembly.GetExecutingAssembly().GetTypes()) 
             {
                 if (type.IsSubclassOf(typeof(Item)) && !type.IsAbstract) 
@@ -251,11 +250,11 @@ namespace DocumentExplorer
         private static ImageList mImageList;
         private Icon mIcon;
 
-        private static readonly List<string> gItemSet;
+        private static readonly List<string> gItemSet = new List<string>();
         private static readonly List<string> gIconNames = new List<string>();
         /// <summary>
         /// Map of character to string that we use to display control MS Word control characters.
         /// </summary>
-        private static readonly Hashtable gControlCharacters = new Hashtable();
+        private static readonly Dictionary<char, string> gControlCharacters = new Dictionary<char, string>();
     }
 }


### PR DESCRIPTION
1) Removed non-generic collections.
2) Fix ExStart, ExEnd, ExFor and ExSkip tags.
3) Removed redundant Equals() calls.